### PR TITLE
Add an example for Brocade IronWare

### DIFF
--- a/brocade-ironware.config
+++ b/brocade-ironware.config
@@ -1,0 +1,17 @@
+# BGP Session Culling Example - Brocade IronWare
+# Culling type: Involuntary BGP Session Teardown
+
+ipv6 access-list bgp-session-culling-v6
+ deny tcp 2001:db8:2::/64 eq bgp 2001:db8:2::/64
+ deny tcp 2001:db8:2::/64 2001:db8:2::/64 eq bgp 
+ permit ipv6 any any 
+!
+ip access-list extended bgp-session-culling-v4
+ deny tcp 192.0.2.0 0.0.0.255 eq bgp 192.0.2.0 0.0.0.255
+ deny tcp 192.0.2.0 0.0.0.255 192.0.2.0 0.0.0.255 eq bgp
+ permit ip any any 
+!
+interface ethernet 1/1
+ ip access-group bgp-session-culling-v4 out 
+ ipv6 traffic-filter bgp-session-culling-v6 out
+!


### PR DESCRIPTION
This configuration example is used for Brocade MLXe series routers (IronWare) in JPNAP. Note that these ACLs must be configured to the outbound direction because an MAC ACL or 'port security' might be configured to the inbound.