### PR TITLE
SONiC unified example

### DIFF
--- a/sonic-unified.json
+++ b/sonic-unified.json
@@ -1,0 +1,47 @@
+{
+    "ACL_TABLE": {
+        "ACL-IPV4V6-PERMIT-ALL-EXCEPT-BGP": {
+            "policy_desc": "IXP Participant Affected by Maintenance",
+            "ports": [
+                "Ethernet8"
+            ],
+            "stage": "ingress",
+            "type": "L3V4V6"
+        }
+    },
+    "ACL_RULE": {
+        "ACL-IPV4V6-PERMIT-ALL-EXCEPT-BGP|DENY-DST-BGPV4": {
+            "PRIORITY": "5",
+            "PACKET_ACTION": "DROP",
+            "SRC_IP": "192.0.2.0/24",
+            "DST_IP": "192.0.2.0/24",
+            "L4_DST_PORT": "179"
+        },
+        "ACL-IPV4V6-PERMIT-ALL-EXCEPT-BGP|DENY-SRC-BGPV4": {
+            "PRIORITY": "4",
+            "PACKET_ACTION": "DROP",
+            "SRC_IP": "192.0.2.0/24",
+            "DST_IP": "192.0.2.0/24",
+            "L4_SRC_PORT": "179"
+        },
+        "ACL-IPV4V6-PERMIT-ALL-EXCEPT-BGP|DENY-DST-BGPV6": {
+            "PRIORITY": "3",
+            "PACKET_ACTION": "DROP",
+            "SRC_IPV6": "2001:db8:2::/64",
+            "DST_IPV6": "2001:db8:2::/64",
+            "L4_DST_PORT": "179"
+        },
+        "ACL-IPV4V6-PERMIT-ALL-EXCEPT-BGP|DENY-SRC-BGPV6": {
+            "PRIORITY": "2",
+            "PACKET_ACTION": "DROP",
+            "SRC_IPV6": "2001:db8:2::/64",
+            "DST_IPV6": "2001:db8:2::/64",
+            "L4_SRC_PORT": "179"
+        },
+        "ACL-IPV4V6-PERMIT-ALL-EXCEPT-BGP|PERMIT-ANY": {
+            "PRIORITY": "1",
+            "PACKET_ACTION": "FORWARD",
+            "IP_TYPE": "ANY"
+        }
+    }
+}


### PR DESCRIPTION
This SONiC configuration example uses the `L3V4V6` ACL table type to replace separate v4/v6 tables on supported ASIC targets. See [SONiC L3V4V6 ACL](https://github.com/sonic-net/SONiC/blob/master/doc/acl/Extend-L3V6ACLs.md) for details.

Deployed at [SONIX](https://sonix.network/)